### PR TITLE
Fix missing second parameter to removeEventListener

### DIFF
--- a/face.html
+++ b/face.html
@@ -65,8 +65,9 @@ body {
 
 var App = {
 	start: function(stream) {
-		App.video.addEventListener('canplay', function() {
-			App.video.removeEventListener('canplay');
+		var listener;
+		App.video.addEventListener('canplay', listener = function() {
+			App.video.removeEventListener('canplay', listener);
 			setTimeout(function() {
 				App.video.play();
 				App.canvas.style.display = 'inline';


### PR DESCRIPTION
Fixes this error that shows up in Firefox:
```
TypeError: Not enough arguments to EventTarget.removeEventListener.
	App.video.removeEventListener('canplay');
```